### PR TITLE
Change instruction for exit interview | Graduation Checklist

### DIFF
--- a/cs-advising/src/Team_Ace/@dInquisitor/GraduationChecklist.jsx
+++ b/cs-advising/src/Team_Ace/@dInquisitor/GraduationChecklist.jsx
@@ -10,7 +10,7 @@ export function GraduationChecklist() {
     "When approved by CEA for graduation, complete the university's graduation application via BisonWeb",
     "Schedule another meeting with your advisor to confirm that you are on track for graduation",
     "If on any financial holds, contact the Bursar's office to clear your holds",
-    "Schedule your exit interview with Dr. Harry Keeling ",
+    "Schedule your exit interview with the Computer Science Program Director",
   ];
   return (
     <div>


### PR DESCRIPTION
Changing the instruction for exit interviews for graduating students to be with the computer science program director.
![image](https://user-images.githubusercontent.com/30784358/201731226-a192de33-d1a8-4e12-928d-cd513e206080.png)
